### PR TITLE
Fix br list not displaying issues since br 0.1.30

### DIFF
--- a/server/api/bd/count.get.ts
+++ b/server/api/bd/count.get.ts
@@ -1,4 +1,4 @@
-import { bdList } from '../../utils/bd-executor'
+import { bdList, unwrapBrEnvelope } from '../../utils/bd-executor'
 
 interface Issue {
   id: string
@@ -21,7 +21,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const issues = (result.data as Issue[]) || []
+  const issues = unwrapBrEnvelope<Issue>(result.data)
 
   // Calculate counts by type
   const byType: Record<string, number> = {

--- a/server/api/bd/list.get.ts
+++ b/server/api/bd/list.get.ts
@@ -1,4 +1,4 @@
-import { bdList } from '../../utils/bd-executor'
+import { bdList, unwrapBrEnvelope } from '../../utils/bd-executor'
 import { transformIssue, priorityToNumber } from '../../utils/bd-transformers'
 
 export default defineEventHandler(async (event) => {
@@ -28,10 +28,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Transform bd CLI response to match Issue type interface
-  const issues = Array.isArray(result.data)
-    ? result.data.map(transformIssue)
-    : []
+  const issues = unwrapBrEnvelope(result.data).map(transformIssue)
 
   return issues
 })

--- a/server/api/bd/ready.get.ts
+++ b/server/api/bd/ready.get.ts
@@ -1,4 +1,4 @@
-import { bdReady } from '../../utils/bd-executor'
+import { bdReady, unwrapBrEnvelope } from '../../utils/bd-executor'
 import { transformIssue } from '../../utils/bd-transformers'
 
 export default defineEventHandler(async (event) => {
@@ -14,10 +14,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Transform bd CLI response to match Issue type interface
-  const issues = Array.isArray(result.data)
-    ? result.data.map(transformIssue)
-    : []
+  const issues = unwrapBrEnvelope(result.data).map(transformIssue)
 
   return issues
 })

--- a/server/utils/bd-executor.ts
+++ b/server/utils/bd-executor.ts
@@ -15,6 +15,24 @@ export interface BdResult<T = unknown> {
 }
 
 /**
+ * Unwrap the paginated envelope returned by br >= 0.1.30 for `list` commands.
+ * br list --json returns {"issues": [...], "total": N, ...} instead of a flat array.
+ * Other commands (show, ready, search) still return flat arrays.
+ */
+export function unwrapBrEnvelope<T = unknown>(data: unknown): T[] {
+  if (Array.isArray(data)) {
+    return data as T[]
+  }
+  if (data && typeof data === 'object' && 'issues' in data) {
+    const envelope = data as { issues: unknown[] }
+    if (Array.isArray(envelope.issues)) {
+      return envelope.issues as T[]
+    }
+  }
+  return []
+}
+
+/**
  * Execute a bd CLI command and return JSON output
  * @param command - The bd command to execute
  * @param options - Options including args and working directory

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -654,10 +654,25 @@ fn parse_issues_tolerant(output: &str, context: &str) -> Result<Vec<BdRawIssue>,
             format!("Invalid JSON: {}", e)
         })?;
 
-    let arr = value.as_array().ok_or_else(|| {
-        log_error!("[{}] Expected array, got: {:?}", context, value);
-        "Expected JSON array".to_string()
-    })?;
+    // br >= 0.1.30 wraps `list` output in a paginated envelope:
+    // {"issues": [...], "total": N, "offset": N, "limit": N, "has_more": bool}
+    // Unwrap the envelope if present, otherwise expect a flat array.
+    let arr_value;
+    let arr = if let Some(obj) = value.as_object() {
+        if let Some(issues) = obj.get("issues").and_then(|v| v.as_array()) {
+            log_info!("[{}] Unwrapped paginated envelope ({} issues)", context, issues.len());
+            arr_value = issues.clone();
+            &arr_value
+        } else {
+            log_error!("[{}] Expected array or envelope with 'issues' key, got object: {:?}", context, obj.keys().collect::<Vec<_>>());
+            return Err("Expected JSON array or paginated envelope".to_string());
+        }
+    } else {
+        value.as_array().ok_or_else(|| {
+            log_error!("[{}] Expected array, got: {:?}", context, value);
+            "Expected JSON array".to_string()
+        })?
+    };
 
     let mut issues = Vec::new();
     let mut failed_count = 0;
@@ -4840,4 +4855,98 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_issue_json(id: &str, title: &str) -> String {
+        format!(
+            r#"{{"id":"{}","title":"{}","description":null,"status":"open","priority":3,"issue_type":"task","owner":null,"assignee":null,"labels":[],"created_at":"2025-01-01T00:00:00Z","created_by":null,"updated_at":"2025-01-01T00:00:00Z","closed_at":null,"close_reason":null,"blocked_by":null,"blocks":null,"comments":null,"external_ref":null,"estimate":null,"design":null,"acceptance_criteria":null,"notes":null,"parent":null,"dependents":null,"dependencies":null,"dependency_count":null,"dependent_count":null,"metadata":null,"spec_id":null,"comment_count":null}}"#,
+            id, title
+        )
+    }
+
+    #[test]
+    fn parse_flat_array() {
+        let json = format!("[{}]", minimal_issue_json("abc-123", "Bug fix"));
+        let result = parse_issues_tolerant(&json, "test_flat");
+        assert!(result.is_ok());
+        let issues = result.unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].id, "abc-123");
+        assert_eq!(issues[0].title, "Bug fix");
+    }
+
+    #[test]
+    fn parse_paginated_envelope() {
+        let json = format!(
+            r#"{{"issues":[{},{}],"total":2,"offset":0,"limit":50,"has_more":false}}"#,
+            minimal_issue_json("abc-123", "First"),
+            minimal_issue_json("def-456", "Second")
+        );
+        let result = parse_issues_tolerant(&json, "test_envelope");
+        assert!(result.is_ok());
+        let issues = result.unwrap();
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].id, "abc-123");
+        assert_eq!(issues[1].id, "def-456");
+    }
+
+    #[test]
+    fn parse_empty_flat_array() {
+        let result = parse_issues_tolerant("[]", "test_empty_flat");
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_empty_envelope() {
+        let json = r#"{"issues":[],"total":0,"offset":0,"limit":50,"has_more":false}"#;
+        let result = parse_issues_tolerant(json, "test_empty_envelope");
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_object_without_issues_key_fails() {
+        let json = r#"{"error":"something went wrong"}"#;
+        let result = parse_issues_tolerant(json, "test_bad_object");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_invalid_json_fails() {
+        let result = parse_issues_tolerant("not json at all", "test_invalid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_real_br_envelope() {
+        // Matches the shape from br 0.1.30+ (`br list --json --limit 1`):
+        // br omits many optional fields (owner, assignee, labels, etc.) and includes extra
+        // fields (source_repo, compaction_level). serde_json defaults missing Option<T> to None
+        // and ignores unknown fields, so this parses correctly.
+        let json = r#"{"issues":[{"id":"proj-abc","title":"Example bug report","description":"A test description","status":"open","priority":2,"issue_type":"bug","created_at":"2025-06-15T09:30:00.000000000Z","updated_at":"2025-06-15T10:45:00.000000000Z","source_repo":".","compaction_level":0,"dependency_count":0,"dependent_count":0}],"total":1,"limit":1,"offset":0,"has_more":true}"#;
+        let result = parse_issues_tolerant(json, "test_real_br");
+        assert!(result.is_ok());
+        let issues = result.unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].id, "proj-abc");
+        assert_eq!(issues[0].issue_type, "bug");
+        assert_eq!(issues[0].priority, 2);
+    }
+
+    #[test]
+    fn parse_envelope_skips_malformed_entries() {
+        let good = minimal_issue_json("abc-123", "Good");
+        let bad = r#"{"id":"bad-456","title":"Bad"}"#; // missing required fields
+        let json = format!(r#"{{"issues":[{},{}],"total":2,"offset":0,"limit":50,"has_more":false}}"#, good, bad);
+        let result = parse_issues_tolerant(&json, "test_tolerant_envelope");
+        assert!(result.is_ok());
+        let issues = result.unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].id, "abc-123");
+    }
 }

--- a/tests/utils/bd-executor.test.ts
+++ b/tests/utils/bd-executor.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { unwrapBrEnvelope } from '../../server/utils/bd-executor'
+
+describe('unwrapBrEnvelope', () => {
+  const sampleIssues = [
+    { id: 'abc-123', title: 'Bug', status: 'open', priority: 2, issue_type: 'bug' },
+    { id: 'def-456', title: 'Task', status: 'closed', priority: 3, issue_type: 'task' },
+  ]
+
+  it('returns flat array as-is (bd / br < 0.1.30)', () => {
+    const result = unwrapBrEnvelope(sampleIssues)
+    expect(result).toEqual(sampleIssues)
+  })
+
+  it('unwraps paginated envelope (br >= 0.1.30)', () => {
+    const envelope = {
+      issues: sampleIssues,
+      total: 2,
+      offset: 0,
+      limit: 50,
+      has_more: false,
+    }
+    const result = unwrapBrEnvelope(envelope)
+    expect(result).toEqual(sampleIssues)
+  })
+
+  it('returns empty array for null/undefined', () => {
+    expect(unwrapBrEnvelope(null)).toEqual([])
+    expect(unwrapBrEnvelope(undefined)).toEqual([])
+  })
+
+  it('returns empty array for non-array, non-envelope object', () => {
+    expect(unwrapBrEnvelope({ error: 'something' })).toEqual([])
+    expect(unwrapBrEnvelope('string data')).toEqual([])
+  })
+
+  it('returns empty array when envelope.issues is not an array', () => {
+    expect(unwrapBrEnvelope({ issues: 'not an array' })).toEqual([])
+    expect(unwrapBrEnvelope({ issues: null })).toEqual([])
+  })
+
+  it('handles empty issues array in envelope', () => {
+    const envelope = { issues: [], total: 0, offset: 0, limit: 50, has_more: false }
+    expect(unwrapBrEnvelope(envelope)).toEqual([])
+  })
+
+  it('handles empty flat array', () => {
+    expect(unwrapBrEnvelope([])).toEqual([])
+  })
+
+  it('handles real br ready output (flat array, fewer fields)', () => {
+    // br ready returns a flat array with a subset of fields
+    const readyIssues = [
+      {
+        created_at: '2025-06-15T09:30:00Z',
+        description: 'Some bug description',
+        id: 'proj-abc',
+        issue_type: 'bug',
+        priority: 1,
+        status: 'open',
+        title: 'Example ready issue',
+        updated_at: '2025-06-15T10:45:00Z',
+      },
+    ]
+    const result = unwrapBrEnvelope(readyIssues)
+    expect(result).toEqual(readyIssues)
+    expect(result).toHaveLength(1)
+  })
+
+  it('handles real br list envelope (extra pagination fields)', () => {
+    // br list --json returns paginated envelope with extra fields
+    const envelope = {
+      issues: [
+        {
+          id: 'proj-abc',
+          title: 'Example bug',
+          description: 'A test description',
+          status: 'open',
+          priority: 2,
+          issue_type: 'bug',
+          created_at: '2025-06-15T09:30:00Z',
+          updated_at: '2025-06-15T10:45:00Z',
+          source_repo: '.',
+          compaction_level: 0,
+          dependency_count: 0,
+          dependent_count: 0,
+        },
+      ],
+      total: 136,
+      limit: 1,
+      offset: 0,
+      has_more: true,
+    }
+    const result = unwrapBrEnvelope(envelope)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toHaveProperty('id', 'proj-abc')
+  })
+})


### PR DESCRIPTION
`br list --json` returns a paginated envelope `{"issues": [...], "total": N, ...}` since br 0.1.30, but the parsing logic only handled flat arrays. Issues silently didn't display.

## Fix

Rust backend: `parse_issues_tolerant()` now detects and unwraps the paginated envelope before parsing individual entries. All 13 call sites benefit automatically.

Server endpoints: new `unwrapBrEnvelope()` helper in `bd-executor.ts` handles both flat arrays (old bd/br) and paginated envelopes. Used in `list.get.ts`, `count.get.ts`, and `ready.get.ts` (defensively).

## Tests

- 8 Rust unit tests for `parse_issues_tolerant()` covering flat arrays, envelopes, empty cases, error objects, invalid JSON, real br output shape, and tolerant parsing
- 9 Vitest tests for `unwrapBrEnvelope()` covering the same edge cases

Tested manually with br 0.1.33 against a project with 136 issues — list displays correctly.

Fixes #17